### PR TITLE
[#36] Feat ArgreementTermsViewController 모달 연결

### DIFF
--- a/LuckVii/LuckVii/Controller/AgreementTermsViewController.swift
+++ b/LuckVii/LuckVii/Controller/AgreementTermsViewController.swift
@@ -1,0 +1,22 @@
+//
+//  AgreementTermsViewController.swift
+//  LuckVii
+//
+//  Created by mun on 12/18/24.
+//
+
+import UIKit
+import SnapKit
+
+class AgreementTermsViewController: UIViewController {
+
+    let agreementTermsView = AgreementTermsView()
+
+    override func loadView() {
+        view = AgreementTermsView()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/LuckVii/LuckVii/Controller/AgreementTermsViewController.swift
+++ b/LuckVii/LuckVii/Controller/AgreementTermsViewController.swift
@@ -8,9 +8,16 @@
 import UIKit
 import SnapKit
 
+// AgreementTermsViewController Delegate 프로토콜
+protocol AgreementTermsViewControllerDelegate: AnyObject {
+    func updateButtonToggle(_ viewController: AgreementTermsViewController, isAgreed: Bool)
+}
+
 class AgreementTermsViewController: UIViewController {
 
     let agreementTermsView = AgreementTermsView()
+
+    weak var delegate: AgreementTermsViewControllerDelegate?
 
     override func loadView() {
         view = agreementTermsView
@@ -18,20 +25,24 @@ class AgreementTermsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         setupAction()
     }
 
     // 버튼 액션 연결
     private func setupAction() {
+        // 동의 버튼 클릭
         agreementTermsView.agreementButton.addAction(UIAction { [weak self] _ in
             guard let self = self else { return }
             self.didTapAreementButton()
+            self.delegate?.updateButtonToggle(self, isAgreed: true) // delegate 지시
+
         }, for: .touchUpInside)
 
+        // 비동의 버튼 클릭
         agreementTermsView.disagreementButton.addAction(UIAction { [weak self] _ in
             guard let self = self else { return }
             self.didTapAreementButton()
+            self.delegate?.updateButtonToggle(self, isAgreed: false) // delegate 지시
         }, for: .touchUpInside)
     }
 

--- a/LuckVii/LuckVii/Controller/AgreementTermsViewController.swift
+++ b/LuckVii/LuckVii/Controller/AgreementTermsViewController.swift
@@ -13,10 +13,30 @@ class AgreementTermsViewController: UIViewController {
     let agreementTermsView = AgreementTermsView()
 
     override func loadView() {
-        view = AgreementTermsView()
+        view = agreementTermsView
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        setupAction()
+    }
+
+    // 버튼 액션 연결
+    private func setupAction() {
+        agreementTermsView.agreementButton.addAction(UIAction { [weak self] _ in
+            guard let self = self else { return }
+            self.didTapAreementButton()
+        }, for: .touchUpInside)
+
+        agreementTermsView.disagreementButton.addAction(UIAction { [weak self] _ in
+            guard let self = self else { return }
+            self.didTapAreementButton()
+        }, for: .touchUpInside)
+    }
+
+    // 버튼 액션 설정
+    private func didTapAreementButton() {
+        self.dismiss(animated: true)
     }
 }

--- a/LuckVii/LuckVii/Controller/AgreementTermsViewController.swift
+++ b/LuckVii/LuckVii/Controller/AgreementTermsViewController.swift
@@ -33,7 +33,7 @@ class AgreementTermsViewController: UIViewController {
         // 동의 버튼 클릭
         agreementTermsView.agreementButton.addAction(UIAction { [weak self] _ in
             guard let self = self else { return }
-            self.didTapAreementButton()
+            self.didTapAgreementButton()
             self.delegate?.updateButtonToggle(self, isAgreed: true) // delegate 지시
 
         }, for: .touchUpInside)
@@ -41,13 +41,13 @@ class AgreementTermsViewController: UIViewController {
         // 비동의 버튼 클릭
         agreementTermsView.disagreementButton.addAction(UIAction { [weak self] _ in
             guard let self = self else { return }
-            self.didTapAreementButton()
+            self.didTapAgreementButton()
             self.delegate?.updateButtonToggle(self, isAgreed: false) // delegate 지시
         }, for: .touchUpInside)
     }
 
     // 버튼 액션 설정
-    private func didTapAreementButton() {
+    private func didTapAgreementButton() {
         self.dismiss(animated: true)
     }
 }

--- a/LuckVii/LuckVii/Controller/PaymentViewController.swift
+++ b/LuckVii/LuckVii/Controller/PaymentViewController.swift
@@ -53,7 +53,25 @@ class PaymentViewController: UIViewController {
 
     // 버튼 액션
     func didTapAreementButton() {
+
+        let agreementTermsVC = AgreementTermsViewController()
+        agreementTermsVC.delegate = self // delegate 설정
+
         self.navigationController?.modalPresentationStyle = .fullScreen
-        present(AgreementTermsViewController(), animated: true)
+        present(agreementTermsVC, animated: true)
+    }
+}
+
+// MARK: - AgreementTermsViewController Delegate
+
+extension PaymentViewController: AgreementTermsViewControllerDelegate {
+
+    func updateButtonToggle(_ viewController: AgreementTermsViewController, isAgreed: Bool) {
+        // 약관 동의 여부 분기 처리
+        if isAgreed {
+            paymentView.termsAgreementButton.isSelected = true // 약관 동의
+        } else {
+            paymentView.termsAgreementButton.isSelected = false // 약관 비동의
+        }
     }
 }

--- a/LuckVii/LuckVii/Controller/PaymentViewController.swift
+++ b/LuckVii/LuckVii/Controller/PaymentViewController.swift
@@ -29,6 +29,7 @@ class PaymentViewController: UIViewController {
 
         configureNavigation()
         configureUI()
+        setupAction()
     }
 
     // 네비게이션 설정
@@ -39,5 +40,20 @@ class PaymentViewController: UIViewController {
 
     private func configureUI() {
         view.backgroundColor = .lightGray
+    }
+
+    // 액션 연결
+    private func setupAction() {
+        paymentView.termsAgreementButton.addAction(UIAction { [weak self] _ in
+            guard let self = self else { return }
+            self.didTapAreementButton()
+
+        }, for: .touchUpInside)
+    }
+
+    // 버튼 액션
+    func didTapAreementButton() {
+        self.navigationController?.modalPresentationStyle = .fullScreen
+        present(AgreementTermsViewController(), animated: true)
     }
 }

--- a/LuckVii/LuckVii/View/PaymentView/AgreementTermsView.swift
+++ b/LuckVii/LuckVii/View/PaymentView/AgreementTermsView.swift
@@ -126,7 +126,7 @@ class AgreementTermsView: UIView {
     }()
 
     //
-    private let disagreementButton: UIButton = {
+    var disagreementButton: UIButton = {
         let button = UIButton()
         button.setTitle("비동의", for: .normal)
         button.backgroundColor = .lightGray
@@ -135,7 +135,7 @@ class AgreementTermsView: UIView {
         return button
     }()
 
-    private let agreementButton: UIButton = {
+    var agreementButton: UIButton = {
         let button = UIButton()
         button.setTitle("전체 동의", for: .normal)
         button.backgroundColor = .systemGreen

--- a/LuckVii/LuckVii/View/PaymentView/PaymentView.swift
+++ b/LuckVii/LuckVii/View/PaymentView/PaymentView.swift
@@ -205,11 +205,11 @@ class PaymentView: UIView {
         return label
     }()
 
-    private let termsAgreementButton: UIButton = {
+    var termsAgreementButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "circle"), for: .normal)
         button.setImage(UIImage(systemName: "checkmark.circle"), for: .selected)
-        button.addTarget(self, action: #selector(didTapAreementButton), for: .touchUpInside)
+
         return button
     }()
 
@@ -457,10 +457,5 @@ class PaymentView: UIView {
             ticketCountLabel.text = "x \(ticketCount)"
         }
         totalPriceLabel.text = "\(PriceFormatModel.wonFormat(ticketCount * 30000))"
-    }
-
-    // 약관 동의 버튼
-    @objc func didTapAreementButton(_ sender: UIButton) {
-        sender.isSelected.toggle()
     }
 }


### PR DESCRIPTION
## 개요 :mag:

`ArgreementTermsViewController`를 모달로 연결하고 약관 버튼 액션을 연결했습니다. 

![Simulator Screen Recording - iPhone 16 - 2024-12-18 at 16 11 02](https://github.com/user-attachments/assets/92d93a7a-2b9b-402e-aebc-55fa1d5689bc)

## 작업사항 :memo:

- `ArgreementTermsViewController` 모달 연결
- `ArgreementTermsViewController` delegate 구현
  - 버튼 클릭시 모달이 종료되고, `PaymentViewController`에서 메서드 실행
  - `모달` 동의 버튼 클릭: `PaymentVC` 동의 버튼 체크 표시
  - `모달` 비동의 버튼 클릭: `PaymentVC` 동의 버튼 체크 표시 X
