### PR TITLE
[#65]: SearchView의 UICollectionView 셀 간격 조정

### DIFF
--- a/LuckVii/LuckVii/Controller/SearchViewController.swift
+++ b/LuckVii/LuckVii/Controller/SearchViewController.swift
@@ -62,8 +62,11 @@ extension SearchViewController: UICollectionViewDataSource, UICollectionViewDele
     
     // 셀 크기 설정
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = 112
-        let height = 198
+        let itemsPerRow: CGFloat = 3 // 가로로 배치할 셀 개수
+        let spcing: CGFloat = collectionView.frame.width * 0.03 // 셀 간 간격 (컬렉션 뷰 너비의 3%)
+        let totalSpacing = (itemsPerRow - 1) * spcing // 전체 간격 계산
+        let width = (collectionView.frame.width - totalSpacing) / itemsPerRow // 셀 너비 계산
+        let height = width * 1.77
         return CGSize(width: width, height: height)
     }
     

--- a/LuckVii/LuckVii/View/SearchView/SearchView.swift
+++ b/LuckVii/LuckVii/View/SearchView/SearchView.swift
@@ -16,6 +16,8 @@ protocol textFieldDelegate: AnyObject {
 
 class SearchView: UIView {
     
+    private let height = UIScreen.main.bounds.height
+    
     weak var delegate: textFieldDelegate?
     
     // 앱 로고 레이블
@@ -80,7 +82,7 @@ class SearchView: UIView {
         ].forEach { addSubview($0) }
         
         logoLabel.snp.makeConstraints{
-            $0.top.equalToSuperview().offset(78)
+            $0.top.equalToSuperview().offset(height / 10) // 전체 높이의 1/10 지점에 세팅
             $0.leading.trailing.equalToSuperview().inset(130)
         }
         


### PR DESCRIPTION
<img width="323" alt="스크린샷 2024-12-18 오후 11 16 53" src="https://github.com/user-attachments/assets/9aea11ef-1954-4116-be49-a2beca237126" />
<img width="317" alt="스크린샷 2024-12-18 오후 11 16 25" src="https://github.com/user-attachments/assets/becea491-4b4b-4cc9-a1eb-6b12db8431c5" />

- 셀 간격 상수로 지정했던 것 화면 크기에 비례하도록 계산하여 se3랑 16pro 화면에도 대응하도록 하였습니다.
- SearchView의 앱 로고 레이블도 화면 전체 크기의 1/10 부분에 위치하도록 하여 전체 UI 위치를 화면 사이즈에 맞게 위치하도록 하였습니다.