### PR TITLE
[#48] Feat 고객 예매 상세페이지 뷰 컨트롤러 구현

### DIFF
--- a/LuckVii/LuckVii/Controller/MainTabs/RvPage/ReservationDetailViewController.swift
+++ b/LuckVii/LuckVii/Controller/MainTabs/RvPage/ReservationDetailViewController.swift
@@ -1,0 +1,50 @@
+//
+//  ReservationDetailViewController.swift
+//  LuckVii
+//
+//  Created by Jamong on 12/19/24.
+//
+
+import UIKit
+import SnapKit
+
+class ReservationDetailViewController: UIViewController {
+   
+   // MARK: - Properties
+   private let detailView = ReservationDetailView()
+   
+   // MARK: - Initialization
+   init() {
+       super.init(nibName: nil, bundle: nil)
+   }
+   
+   required init?(coder: NSCoder) {
+       fatalError("init(coder:) has not been implemented")
+   }
+   
+   // MARK: - Lifecycle
+   override func loadView() {
+       view = detailView
+   }
+   
+   override func viewDidLoad() {
+       super.viewDidLoad()
+       view.backgroundColor = .white
+       setupUI()
+       // 화면을 테스트하기 위해 임시 데이터를 configure로 전달
+       detailView.configure(
+           with: MovieReservation(
+               title: "테스트 영화",
+               dateTime: "2024.12.16 (월) 15:00~16:00 관람",
+               theater: "테스트 극장",
+               price: 0,
+               posterImage: nil as String?
+           )
+       )
+   }
+   
+   // MARK: - Setup
+   private func setupUI() {
+       navigationItem.title = "예매 상세 내역"
+   }
+}


### PR DESCRIPTION
## 개요 🔍
 고객 예매 상세페이지 뷰 컨트롤러 구현
![Simulator Screenshot - iPhone 16 Pro - 2024-12-19 at 15 05 17](https://github.com/user-attachments/assets/2ec3e4ae-f144-43ce-8d6f-904b89c06507)
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-12-19 at 15 05 16](https://github.com/user-attachments/assets/8e0c20dc-8a60-418f-aa77-c6ae3a2aa782)


## 작업사항 📝
- ReservationDetailViewController
    - 더미데이터 확인용으로 넣은 상태

## 앞으로 계획
- 로그인 데이터 (유저 데이터) 마이페이지 연결하기
- 마이페이지 테이블 셀과 고객 예매 상세페이지 뷰 컨트롤러 연결하기 및 데이터 가져오기
- 코어데이터 구조 확인하기
