### PR TITLE
[#100] Feat payment alert

### DIFF
--- a/LuckVii/LuckVii/Controller/MainTabs/Category/CategoryViewController.swift
+++ b/LuckVii/LuckVii/Controller/MainTabs/Category/CategoryViewController.swift
@@ -26,7 +26,7 @@ final class CategoryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        title = "Movies"
+        title = "Luck VII"
         
         insertMovieData()
         setupScrollView()

--- a/LuckVii/LuckVii/Controller/Payment/PaymentResultViewController.swift
+++ b/LuckVii/LuckVii/Controller/Payment/PaymentResultViewController.swift
@@ -19,11 +19,9 @@ import UIKit
  5,000원 5%
  */
 class PaymentResultViewController: UIViewController {
-    
     let paymentResultView = PaymentResultView()
     
     var ticketNumber: Int = 0 // 티켓 번호
-
     var ticketCount: Int? // 티켓 갯수
 
     override func loadView() {
@@ -127,8 +125,23 @@ class PaymentResultViewController: UIViewController {
 
     // 티켓 뽑기 종료
     private func complete() {
-        self.navigationController?.popToRootViewController(animated: true)
-        tabBarController?.tabBar.isHidden = false
+        Task {
+            await presentCompletePayAlert(on: self)
+            self.navigationController?.popToRootViewController(animated: true)
+            tabBarController?.tabBar.isHidden = false
+        }
+    }
+    
+    //결제 완료 시 알럿 await 사용을 비동기작업이지만 동기적으로 읽을 수 있게 처리
+    private func presentCompletePayAlert(on viewController: UIViewController) async {
+        await withCheckedContinuation { continuation in
+            let alert = UIAlertController(title: "결제 완료", message: "테스트\n\n\n\n\n\n\n\n\n\\n\n아", preferredStyle: .actionSheet)
+            let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
+                continuation.resume()
+            }
+            alert.addAction(confirmAction)
+            viewController.present(alert, animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
# 주요 변경 사항
- **`presentCompletePayAlert(on viewController: UIViewController) async`**: 결제 완료 시 사용자에게 Action Sheet 스타일 알림을 표시하며, 비동기 작업을 동기적으로 처리할 수 있게 구현된 메서드.

---

## **presentCompletePayAlert**
결제 완료 시 Action Sheet 스타일 알림을 사용자에게 표시하고, 확인 버튼을 누를 때까지 비동기 작업을 대기합니다.

### **프로퍼티**
- **`viewController`**: 알림을 표시할 `UIViewController`.

### **메서드**
- **`presentCompletePayAlert(on viewController: UIViewController) async`**  
  - **설명**:  
    이 메서드는 `UIAlertController`를 사용해 결제 완료 알림을 표시하며, 사용자가 확인 버튼을 누르면 작업이 재개됩니다. `withCheckedContinuation`을 활용해 비동기 작업을 동기적으로 제어합니다.  
  - **사용 예시**:  
    ```swift
    private func presentCompletePayAlert(on viewController: UIViewController) async {
        await withCheckedContinuation { continuation in
            let alert = UIAlertController(title: "결제 완료", message: "테스트\n\n\n\n\n\n\n\n\n\n아", preferredStyle: .actionSheet)
            let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
                continuation.resume()
            }
            alert.addAction(confirmAction)
            viewController.present(alert, animated: true)
        }
    }
    ```